### PR TITLE
VehiclesRework: also lock statics to defined teams.

### DIFF
--- a/mission/functions/systems/vehicle_locking/fn_player_can_enter_vehicle.sqf
+++ b/mission/functions/systems/vehicle_locking/fn_player_can_enter_vehicle.sqf
@@ -20,7 +20,7 @@
 
 
 /* Local function to check player AuthZ */
-private _fnc_get_valid_team_result = {
+private _fnc_player_is_authorized = {
 	params ["_vehicle", "_player"];
 
 	private _teamsVehicleIsLockedTo = _vehicle getVariable ["teamLock", []];
@@ -43,7 +43,7 @@ params ["_player", "_role", "_vehicle"];
 
 /* statics -- only AuthZ'd players */
 if (_vehicle isKindOf "StaticWeapon") exitWith {
-	[_vehicle, _player] call _fnc_get_valid_team_result
+	[_vehicle, _player] call _fnc_player_is_authorized
 };
 
 private _isCopilot = (getNumber ([_vehicle, _vehicle unitTurret _player] call BIS_fnc_turretConfig >> "isCopilot") > 0);
@@ -56,7 +56,7 @@ other vehicles
 */
 
 if (_role == "driver" || _isCoPilot) exitWith {
-	[_vehicle, _player] call _fnc_get_valid_team_result
+	[_vehicle, _player] call _fnc_player_is_authorized
 };
 
 true

--- a/mission/functions/systems/vehicle_locking/fn_player_can_enter_vehicle.sqf
+++ b/mission/functions/systems/vehicle_locking/fn_player_can_enter_vehicle.sqf
@@ -5,6 +5,7 @@
 
 	Description:
 		Check if the player can enter the vehicle.
+		'DJ' Note -- this is a basic authorization/permissions check (AuthZ)
 
 	Parameter(s):
 	_player - Player that wants to enter [Object]
@@ -18,24 +19,44 @@
 */
 
 
+/* Local function to check player AuthZ */
+private _fnc_get_valid_team_result = {
+	params ["_vehicle", "_player"];
+
+	private _teamsVehicleIsLockedTo = _vehicle getVariable ["teamLock", []];
+	private _playerGroup = _player getVariable ["vn_mf_db_player_group", "FAILED"];
+
+	if (!(_teamsVehicleIsLockedTo isEqualTo [])) then {
+		_teamsVehicleIsLockedTo = _teamsVehicleIsLockedTo select 0;
+	};
+
+	if (
+		_playerGroup in _teamsVehicleIsLockedTo
+		|| typeName _teamsVehicleIsLockedTo != "ARRAY"
+		|| count(_teamsVehicleIsLockedTo) isEqualTo 0
+	) exitWith {true};
+
+	false
+};
+
 params ["_player", "_role", "_vehicle"];
 
+/* statics -- only AuthZ'd players */
+if (_vehicle isKindOf "StaticWeapon") exitWith {
+	[_vehicle, _player] call _fnc_get_valid_team_result
+};
+
 private _isCopilot = (getNumber ([_vehicle, _vehicle unitTurret _player] call BIS_fnc_turretConfig >> "isCopilot") > 0);
-private _playerGroup = _player getVariable ["vn_mf_db_player_group", "FAILED"];
 
-if (_role == "driver" || _isCopilot) exitWith {
-    private _teamsVehicleIsLockedTo = _vehicle getVariable ["teamLock", []];
-    if (!(_teamsVehicleIsLockedTo isEqualTo [])) then {
-        _teamsVehicleIsLockedTo = _teamsVehicleIsLockedTo select 0;
-    };
+/*
+other vehicles
 
-    if (_playerGroup in _teamsVehicleIsLockedTo || typeName _teamsVehicleIsLockedTo != "ARRAY" || count(_teamsVehicleIsLockedTo) isEqualTo 0) exitWith {
-        true
-    };
+- only authZ'd players can get in as pilot/driver/copilot
+- all players can get in as passangers
+*/
 
-
-    false
-
+if (_role == "driver" || _isCoPilot) exitWith {
+	[_vehicle, _player] call _fnc_get_valid_team_result
 };
 
 true


### PR DESCRIPTION
- Move AuthZ logic out to a separate local function call
- Apply AuthZ check to static weapons and vehicles.

Tested on 105 Arty and Dac Cong assets as non BlackHorse blufor ✅ 