### PR TITLE
VehicleRework: Fixup scroll wheel display vehicle icons from category

### DIFF
--- a/mission/functions/systems/vehicle_asset_manager/client/fn_veh_asset_finalise_spawn_point_setup_on_client.sqf
+++ b/mission/functions/systems/vehicle_asset_manager/client/fn_veh_asset_finalise_spawn_point_setup_on_client.sqf
@@ -56,7 +56,7 @@ private _vehicleCategories = _spawnPoint get "settings" get "categories";
         private _vehicle = _x;
         createHashMapFromArray [
             ["text", getText (configFile >> "CfgVehicles" >> (_vehicle get "classname") >> "displayName")],
-            ["iconPath", _vehicle get "icon"],
+            ["iconPath", _category get "icon"],
             ["functionArguments", [_spawnPoint get "id", _vehicle get "classname"]],
             ["function", "vn_mf_fnc_veh_asset_request_vehicle_change_client"]
         ]


### PR DESCRIPTION
Vehicles don't have icons data provided in the configs.

It seems like we were supposed to be able to editing vehicle specific respawn configs to have an icon, see the below

```
	class vn_b_air_ch47_01_01 {
		tags[] = {"ch47","armed","transport","helicopter","army"};
		icon = VEHICLE_ICON_CAR;
	};
```

However

- this config ^ doesn't show the icon (it doesn't work)
- it would be tedious when we've already done the same for categories
- vehicle icons will likely just be the same as the category anyway

Instead, we can keep life simple, and just grab the top level category icon as a surrogate icon for each vehicle.

Before:

![20240406140001_1](https://github.com/Huckleberry87/Mike-Force/assets/11841332/1c303667-4f3d-4a9f-bbaf-18cc498b1d92)

After:

![20240422123701_1](https://github.com/Huckleberry87/Mike-Force/assets/11841332/3b9d9084-5c29-4d55-abf8-910b25c289a5)
